### PR TITLE
"?query=c" is an invalid parameter for an API call

### DIFF
--- a/charts.php
+++ b/charts.php
@@ -94,7 +94,7 @@
 				
 				if (!empty($plexWatch['myPlexAuthToken'])) {
 					$myPlexAuthToken = $plexWatch['myPlexAuthToken'];
-               if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/status/sessions?query=c&X-Plex-Token=".$myPlexAuthToken."")) {
+               if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/status/sessions?X-Plex-Token=".$myPlexAuthToken."")) {
                   $statusSessions = simplexml_load_string($fileContents) or die ("Failed to access Plex Media Server. Please check your settings.");
                }
 

--- a/includes/current_activity.php
+++ b/includes/current_activity.php
@@ -12,7 +12,7 @@ $fileContents = '';
 
 if (!empty($plexWatch['myPlexAuthToken'])) {
 	$myPlexAuthToken = $plexWatch['myPlexAuthToken'];			
-	if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/status/sessions?query=c&X-Plex-Token=".$plexWatch['myPlexAuthToken']."")) {
+	if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/status/sessions?X-Plex-Token=".$plexWatch['myPlexAuthToken']."")) {
       $statusSessions = simplexml_load_string($fileContents) or die ('<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>');	
    }
 }else{

--- a/includes/current_activity_header.php
+++ b/includes/current_activity_header.php
@@ -12,7 +12,7 @@ $fileContents = '';
 
 if (!empty($plexWatch['myPlexAuthToken'])) {
         $myPlexAuthToken = $plexWatch['myPlexAuthToken'];                        
-        if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/status/sessions?query=c&X-Plex-Token=".$plexWatch['myPlexAuthToken']."")) {
+        if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/status/sessions?X-Plex-Token=".$plexWatch['myPlexAuthToken']."")) {
       		$statusSessions = simplexml_load_string($fileContents) or die ('<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>');
   		}
 }else{

--- a/includes/recently_added.php
+++ b/includes/recently_added.php
@@ -24,12 +24,12 @@ if (isset($_GET['width'])) {
 
 			if (!empty($plexWatch['myPlexAuthToken'])) {
 				$myPlexAuthToken = $plexWatch['myPlexAuthToken'];
-            if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/library/recentlyAdded?query=c&X-Plex-Container-Start=0&X-Plex-Container-Size=".$containerSize."&X-Plex-Token=".$myPlexAuthToken."")) {
+            if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/library/recentlyAdded?X-Plex-Container-Start=0&X-Plex-Container-Size=".$containerSize."&X-Plex-Token=".$myPlexAuthToken."")) {
                $recentRequest = simplexml_load_string($fileContents) or die ("<div class='alert alert-warning'>Failed to access Plex Media Server. Please check your settings.</div>");
             }
 			}else{
 				$myPlexAuthToken = '';
-				if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/library/recentlyAdded?query=c&X-Plex-Container-Start=0&X-Plex-Container-Size=".$containerSize)) {
+				if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/library/recentlyAdded?X-Plex-Container-Start=0&X-Plex-Container-Size=".$containerSize)) {
                $recentRequest = simplexml_load_string($fileContents) or die ("<div class='alert alert-warning'>Failed to access Plex Media Server. Please check your settings.</div>");
             }
 

--- a/index.php
+++ b/index.php
@@ -79,13 +79,13 @@
 				if (!empty($plexWatch['myPlexAuthToken'])) {
 					$myPlexAuthToken = $plexWatch['myPlexAuthToken'];
 					$fileContents = '';
-					if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/status/sessions?query=c&X-Plex-Token=".$myPlexAuthToken."")) {
+					if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/status/sessions?X-Plex-Token=".$myPlexAuthToken."")) {
  	             		$statusSessions = simplexml_load_string($fileContents) or die ("<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>");
                  	}
-					$sections = simplexml_load_file("".$plexWatchPmsUrl."/library/sections?query=c&X-Plex-Token=".$myPlexAuthToken."") or die ("<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>");
+					$sections = simplexml_load_file("".$plexWatchPmsUrl."/library/sections?X-Plex-Token=".$myPlexAuthToken."") or die ("<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>");
 				}else{
 					$myPlexAuthToken = '';
-					if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/status/sessions?query=c&X-Plex-Token=".$myPlexAuthToken."")) {
+					if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/status/sessions?X-Plex-Token=".$myPlexAuthToken."")) {
  	             		$statusSessions = simplexml_load_string($fileContents) or die ("<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>");
                  	}
 					$sections = simplexml_load_file("".$plexWatchPmsUrl."/library/sections") or die ("<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>");	

--- a/info.php
+++ b/info.php
@@ -72,7 +72,7 @@
 		if (!empty($plexWatch['myPlexAuthToken'])) {
 			$myPlexAuthToken = $plexWatch['myPlexAuthToken'];
 			$id = $_GET['id'];
-			$infoUrl = "".$plexWatchPmsUrl."/library/metadata/".$id."?query=c&X-Plex-Token=".$myPlexAuthToken."";
+			$infoUrl = "".$plexWatchPmsUrl."/library/metadata/".$id."?X-Plex-Token=".$myPlexAuthToken."";
 		}else{
 			$myPlexAuthToken = '';		
 			$id = $_GET['id'];
@@ -537,7 +537,7 @@
 						}else if ($xml->Directory['type'] == "season") {
 							
 							if (!empty($plexWatch['myPlexAuthToken'])) {
-								$parentInfoUrl = "".$plexWatchPmsUrl."/library/metadata/".$xml->Directory['parentRatingKey']."?query=c&X-Plex-Token=".$myPlexAuthToken."";
+								$parentInfoUrl = "".$plexWatchPmsUrl."/library/metadata/".$xml->Directory['parentRatingKey']."?X-Plex-Token=".$myPlexAuthToken."";
 							}else{
 								$parentInfoUrl = "".$plexWatchPmsUrl."/library/metadata/".$xml->Directory['parentRatingKey']."";
 							}
@@ -613,7 +613,7 @@
 						echo "</div>"; 
 								
 								if (!empty($plexWatch['myPlexAuthToken'])) {
-									$seasonEpisodesUrl = "".$plexWatchPmsUrl."/library/metadata/".$id."/children?query=c&X-Plex-Token=".$myPlexAuthToken."";
+									$seasonEpisodesUrl = "".$plexWatchPmsUrl."/library/metadata/".$id."/children?X-Plex-Token=".$myPlexAuthToken."";
 								}else{
 									$seasonEpisodesUrl = "".$plexWatchPmsUrl."/library/metadata/".$id."/children";
 								}	

--- a/user.php
+++ b/user.php
@@ -486,7 +486,7 @@
 									if ($recentXml['type'] == "episode") {
 										if (!empty($plexWatch['myPlexAuthToken'])) {
 											$myPlexAuthToken = $plexWatch['myPlexAuthToken'];
-											$recentMetadata = "".$plexWatchPmsUrl."/library/metadata/".$recentXml['ratingKey']."?query=c&X-Plex-Token=".$myPlexAuthToken."";
+											$recentMetadata = "".$plexWatchPmsUrl."/library/metadata/".$recentXml['ratingKey']."?X-Plex-Token=".$myPlexAuthToken."";
 										}else{
 											$myPlexAuthToken = '';
 											$recentMetadata = "".$plexWatchPmsUrl."/library/metadata/".$recentXml['ratingKey']."";
@@ -516,7 +516,7 @@
 									}else if ($recentXml['type'] == "movie") {	
 										if (!empty($plexWatch['myPlexAuthToken'])) {
 											$myPlexAuthToken = $plexWatch['myPlexAuthToken'];
-											$recentMetadata = "".$plexWatchPmsUrl."/library/metadata/".$recentXml['ratingKey']."?query=c&X-Plex-Token=".$myPlexAuthToken."";
+											$recentMetadata = "".$plexWatchPmsUrl."/library/metadata/".$recentXml['ratingKey']."?X-Plex-Token=".$myPlexAuthToken."";
 										}else{
 											$myPlexAuthToken = '';
 											$recentMetadata = "".$plexWatchPmsUrl."/library/metadata/".$recentXml['ratingKey']."";
@@ -547,7 +547,7 @@
 									}else if ($recentXml['type'] == "clip") {	
 										if (!empty($plexWatch['myPlexAuthToken'])) {
 											$myPlexAuthToken = $plexWatch['myPlexAuthToken'];
-											$recentMetadata = "".$plexWatchPmsUrl."/library/metadata/".$recentXml['ratingKey']."?query=c&X-Plex-Token=".$myPlexAuthToken."";
+											$recentMetadata = "".$plexWatchPmsUrl."/library/metadata/".$recentXml['ratingKey']."?X-Plex-Token=".$myPlexAuthToken."";
 										}else{
 											$myPlexAuthToken = '';
 											$recentMetadata = "".$plexWatchPmsUrl."/library/metadata/".$recentXml['ratingKey']."";


### PR DESCRIPTION
- This will result in a 500 error on any PMS > v0.9.9.5
- I really do not remember why I had that code in plexWatch either. I do not believe it did anything before.
