### PR TITLE
Fix issue where times are displayed incorrectly in certain areas if php's timezone is different than the system's.

### DIFF
--- a/history.php
+++ b/history.php
@@ -72,7 +72,7 @@
 
 	<?php
 	
-	date_default_timezone_set(@date_default_timezone_get());
+	$tzOffset = date('Z');
 	
 	
 	
@@ -109,14 +109,14 @@
 					if ($plexWatch['globalHistoryGrouping'] == "yes") {
 						$plexWatchDbTable = "grouped";
 						$numRows = $db->querySingle("SELECT COUNT(*) as count FROM $plexWatchDbTable ");
-						$results = $db->query("SELECT title, user, platform, time, stopped, ip_address, xml, paused_counter, strftime('%Y%m%d', datetime(time, 'unixepoch', 'localtime')) as date FROM processed WHERE stopped IS NULL UNION ALL SELECT title, user, platform, time, stopped, ip_address, xml, paused_counter, strftime('%Y%m%d', datetime(time, 'unixepoch', 'localtime')) as date FROM $plexWatchDbTable ORDER BY time DESC") or die ("Failed to access plexWatch database. Please check your settings.");
+						$results = $db->query("SELECT title, user, platform, time, stopped, ip_address, xml, paused_counter, strftime('%Y%m%d', datetime(time, 'unixepoch', '$tzOffset seconds')) as date FROM processed WHERE stopped IS NULL UNION ALL SELECT title, user, platform, time, stopped, ip_address, xml, paused_counter, strftime('%Y%m%d', datetime(time, 'unixepoch', '$tzOffset seconds')) as date FROM $plexWatchDbTable ORDER BY time DESC") or die ("Failed to access plexWatch database. Please check your settings.");
 							
 						
 					}else if ($plexWatch['globalHistoryGrouping'] == "no") {
 						$plexWatchDbTable = "processed";
 					
 						$numRows = $db->querySingle("SELECT COUNT(*) as count FROM $plexWatchDbTable ");
-						$results = $db->query("SELECT title, user, platform, time, stopped, ip_address, xml, paused_counter, strftime('%Y%m%d', datetime(time, 'unixepoch', 'localtime')) as date FROM $plexWatchDbTable ORDER BY time DESC") or die ("Failed to access plexWatch database. Please check settings.");
+						$results = $db->query("SELECT title, user, platform, time, stopped, ip_address, xml, paused_counter, strftime('%Y%m%d', datetime(time, 'unixepoch', '$tzOffset seconds')) as date FROM $plexWatchDbTable ORDER BY time DESC") or die ("Failed to access plexWatch database. Please check settings.");
 					}	
 						
 					

--- a/info.php
+++ b/info.php
@@ -79,7 +79,7 @@
 			$infoUrl = "".$plexWatchPmsUrl."/library/metadata/".$id."";
 		}
 		
-		date_default_timezone_set(@date_default_timezone_get());
+		$tzOffset = date('Z');
 		
 		
 					
@@ -181,7 +181,7 @@
 							
 							$title = $db->querySingle("SELECT title FROM $plexWatchDbTable WHERE session_id LIKE '%/metadata/".$id."\_%' ESCAPE '\'  ");
 							$numRows = $db->querySingle("SELECT COUNT(*) as count FROM $plexWatchDbTable WHERE session_id LIKE '%/metadata/".$id."\_%' ESCAPE '\' ORDER BY time DESC");
-							$results = $db->query("SELECT title, user, platform, time, stopped, ip_address, xml, paused_counter, strftime('%Y%m%d', datetime(time, 'unixepoch', 'localtime')) as date FROM $plexWatchDbTable WHERE session_id LIKE '%/metadata/".$id."\_%' ESCAPE '\' ORDER BY time DESC");
+							$results = $db->query("SELECT title, user, platform, time, stopped, ip_address, xml, paused_counter, strftime('%Y%m%d', datetime(time, 'unixepoch', '$tzOffset seconds')) as date FROM $plexWatchDbTable WHERE session_id LIKE '%/metadata/".$id."\_%' ESCAPE '\' ORDER BY time DESC");
 							
 							echo "<div class='dashboard-wellheader'>";
 									echo"<h3>Watching history for <strong>".$xml->Video['title']."</strong> (".$numRows." Views)</h3>";

--- a/stats.php
+++ b/stats.php
@@ -72,7 +72,7 @@
 
 	<?php
 	
-	date_default_timezone_set(@date_default_timezone_get());
+	$tzOffset = date('Z');
 	
 	
 	
@@ -131,7 +131,7 @@
 						$results = $db->query("SELECT title, user, platform, time, stopped, ip_address, xml, paused_counter FROM $plexWatchDbTable ORDER BY time DESC") or die ("Failed to access plexWatch database. Please check settings.");
 					}	
 						
-					$hourlyPlays = $db->query("SELECT strftime('%Y-%m-%d %H', datetime(time, 'unixepoch', 'localtime')) as date, COUNT(title) as count FROM $plexWatchDbTable WHERE datetime(time, 'unixepoch', 'localtime') >= datetime('now', '-24 hours', 'localtime') GROUP BY strftime('%Y-%m-%d %H', datetime(time, 'unixepoch', 'localtime')) ORDER BY date ASC;") or die ("Failed to access plexWatch database. Please check your settings.");
+					$hourlyPlays = $db->query("SELECT strftime('%Y-%m-%d %H', datetime(time, 'unixepoch', '$tzOffset seconds')) as date, COUNT(title) as count FROM $plexWatchDbTable WHERE datetime(time, 'unixepoch', '$tzOffset seconds') >= datetime('now', '-24 hours', '$tzOffset seconds') GROUP BY strftime('%Y-%m-%d %H', datetime(time, 'unixepoch', '$tzOffset seconds')) ORDER BY date ASC;") or die ("Failed to access plexWatch database. Please check your settings.");
 					$hourlyPlaysNum = 0;
 					$hourlyPlayFinal = '';
 					while ($hourlyPlay = $hourlyPlays->fetchArray()) {
@@ -142,7 +142,7 @@
 						$hourlyPlayFinal .= $hourlyPlayTotal;
 					}
 
-					$maxhourlyPlays = $db->query("SELECT strftime('%Y-%m-%d %H', datetime(time, 'unixepoch', 'localtime')) as date, COUNT(title) as count FROM $plexWatchDbTable GROUP BY strftime('%Y-%m-%d %H', datetime(time, 'unixepoch', 'localtime')) ORDER BY count(*) desc limit 25;") or die ("Failed to access plexWatch database. Please check your settings.");
+					$maxhourlyPlays = $db->query("SELECT strftime('%Y-%m-%d %H', datetime(time, 'unixepoch', '$tzOffset seconds')) as date, COUNT(title) as count FROM $plexWatchDbTable GROUP BY strftime('%Y-%m-%d %H', datetime(time, 'unixepoch', '$tzOffset seconds')) ORDER BY count(*) desc limit 25;") or die ("Failed to access plexWatch database. Please check your settings.");
 					$maxhourlyPlaysNum = 0;
 					$maxhourlyPlayFinal = '';
 					while ($maxhourlyPlay = $maxhourlyPlays->fetchArray()) {
@@ -155,7 +155,7 @@
 						
 							
 						
-					$dailyPlays = $db->query("SELECT date(time, 'unixepoch','localtime') as date, count(title) as count FROM $plexWatchDbTable GROUP BY date ORDER BY time DESC LIMIT 30") or die ("Failed to access plexWatch database. Please check your settings.");
+					$dailyPlays = $db->query("SELECT date(time, 'unixepoch','$tzOffset seconds') as date, count(title) as count FROM $plexWatchDbTable GROUP BY date ORDER BY time DESC LIMIT 30") or die ("Failed to access plexWatch database. Please check your settings.");
 					$dailyPlaysNum = 0;
 					$dailyPlayFinal = '';
 					while ($dailyPlay = $dailyPlays->fetchArray()) {
@@ -166,7 +166,7 @@
 						$dailyPlayFinal .= $dailyPlayTotal;
 					}
 						
-					$monthlyPlays = $db->query("SELECT strftime('%Y-%m', datetime(time, 'unixepoch', 'localtime')) as date, COUNT(title) as count FROM $plexWatchDbTable WHERE datetime(time, 'unixepoch', 'localtime') >= datetime('now', '-12 months', 'localtime') GROUP BY strftime('%Y-%m', datetime(time, 'unixepoch', 'localtime'))  ORDER BY date DESC LIMIT 6;") or die ("Failed to access plexWatch database. Please check your settings.");
+					$monthlyPlays = $db->query("SELECT strftime('%Y-%m', datetime(time, 'unixepoch', '$tzOffset seconds')) as date, COUNT(title) as count FROM $plexWatchDbTable WHERE datetime(time, 'unixepoch', '$tzOffset seconds') >= datetime('now', '-12 months', '$tzOffset seconds') GROUP BY strftime('%Y-%m', datetime(time, 'unixepoch', '$tzOffset seconds'))  ORDER BY date DESC LIMIT 6;") or die ("Failed to access plexWatch database. Please check your settings.");
 					$monthlyPlaysNum = 0;
 					$monthlyPlayFinal = '';
 					while ($monthlyPlay = $monthlyPlays->fetchArray()) {

--- a/user.php
+++ b/user.php
@@ -54,7 +54,7 @@
     </div>
 	<?php
 	
-	date_default_timezone_set(@date_default_timezone_get());
+	$tzOffset = date('Z');
 	
 	$guisettingsFile = "config/config.php";
 	
@@ -85,9 +85,9 @@
 	$numRows = $db->querySingle("SELECT COUNT(*) as count FROM ".$plexWatchDbTable." ");
 	$userInfo = $db->query("SELECT user,xml FROM ".$plexWatchDbTable." WHERE user = '$user' ORDER BY time DESC LIMIT 1") or die ("Failed to access plexWatch database. Please check your settings.");
 	
-	$userStatsDailyCount = $db->querySingle("SELECT COUNT(*) FROM ".$plexWatchDbTable." WHERE datetime(stopped, 'unixepoch', 'localtime') >= date('now', 'localtime') AND user='$user' ");
+	$userStatsDailyCount = $db->querySingle("SELECT COUNT(*) FROM ".$plexWatchDbTable." WHERE datetime(stopped, 'unixepoch', '$tzOffset seconds') >= date('now', '$tzOffset seconds') AND user='$user' ");
 	
-	$userStatsDailyTimeFetch = $db->query("SELECT time,stopped,paused_counter FROM ".$plexWatchDbTable." WHERE datetime(stopped, 'unixepoch', 'localtime') >= date('now', 'localtime') AND user='$user' ");
+	$userStatsDailyTimeFetch = $db->query("SELECT time,stopped,paused_counter FROM ".$plexWatchDbTable." WHERE datetime(stopped, 'unixepoch', '$tzOffset seconds') >= date('now', '$tzOffset seconds') AND user='$user' ");
 	$userStatsDailyTimeViewedTime = 0;
 	while ($userStatsDailyTimeRow = $userStatsDailyTimeFetch->fetchArray()) {
 		$userStatsDailyTimeToTimeRow = strtotime(date("m/d/Y g:i a",$userStatsDailyTimeRow['stopped']));
@@ -103,9 +103,9 @@
 	}								
 	
 
-	$userStatsWeeklyCount = $db->querySingle("SELECT COUNT(*) FROM ".$plexWatchDbTable." WHERE datetime(stopped, 'unixepoch') >= datetime('now', '-7 days', 'localtime') AND user='$user' ");
+	$userStatsWeeklyCount = $db->querySingle("SELECT COUNT(*) FROM ".$plexWatchDbTable." WHERE datetime(stopped, 'unixepoch') >= datetime('now', '-7 days', '$tzOffset seconds') AND user='$user' ");
 	
-	$userStatsWeeklyTimeFetch = $db->query("SELECT time,stopped,paused_counter FROM ".$plexWatchDbTable." WHERE datetime(stopped, 'unixepoch', 'localtime') >= datetime('now', '-7 days', 'localtime') AND user='$user' ");
+	$userStatsWeeklyTimeFetch = $db->query("SELECT time,stopped,paused_counter FROM ".$plexWatchDbTable." WHERE datetime(stopped, 'unixepoch', '$tzOffset seconds') >= datetime('now', '-7 days', '$tzOffset seconds') AND user='$user' ");
 	$userStatsWeeklyTimeViewedTime = 0;
 	while ($userStatsWeeklyTimeRow = $userStatsWeeklyTimeFetch->fetchArray()) {
 		$userStatsWeeklyTimeToTimeRow = strtotime(date("m/d/Y g:i a",$userStatsWeeklyTimeRow['stopped']));
@@ -121,9 +121,9 @@
 	}
 	
 	
-	$userStatsMonthlyCount = $db->querySingle("SELECT COUNT(*) FROM ".$plexWatchDbTable." WHERE datetime(stopped, 'unixepoch', 'localtime') >= datetime('now', '-30 days', 'localtime') AND user='$user' ");
+	$userStatsMonthlyCount = $db->querySingle("SELECT COUNT(*) FROM ".$plexWatchDbTable." WHERE datetime(stopped, 'unixepoch', '$tzOffset seconds') >= datetime('now', '-30 days', '$tzOffset seconds') AND user='$user' ");
 	
-	$userStatsMonthlyTimeFetch = $db->query("SELECT time,stopped,paused_counter FROM ".$plexWatchDbTable." WHERE datetime(stopped, 'unixepoch', 'localtime') >= datetime('now', '-30 days', 'localtime') AND user='$user' ");
+	$userStatsMonthlyTimeFetch = $db->query("SELECT time,stopped,paused_counter FROM ".$plexWatchDbTable." WHERE datetime(stopped, 'unixepoch', '$tzOffset seconds') >= datetime('now', '-30 days', '$tzOffset seconds') AND user='$user' ");
 	$userStatsMonthlyTimeViewedTime = 0;
 	while ($userStatsMonthlyTimeRow = $userStatsMonthlyTimeFetch->fetchArray()) {
 		$userStatsMonthlyTimeToTimeRow = strtotime(date("m/d/Y g:i a",$userStatsMonthlyTimeRow['stopped']));
@@ -158,9 +158,9 @@
 	}
 	
 	if ($plexWatch['userHistoryGrouping'] == "yes") {
-		$results = $db->query("SELECT title, user, platform, time, stopped, ip_address, xml, paused_counter, strftime('%Y%m%d', datetime(time, 'unixepoch', 'localtime')) as date FROM processed WHERE user = '$user' AND stopped IS NULL UNION ALL SELECT title, user, platform, time, stopped, ip_address, xml, paused_counter, strftime('%Y%m%d', datetime(time, 'unixepoch', 'localtime')) as date FROM ".$plexWatchDbTable." WHERE user = '$user' ORDER BY time DESC") or die ("Failed to access plexWatch database. Please check your settings.");
+		$results = $db->query("SELECT title, user, platform, time, stopped, ip_address, xml, paused_counter, strftime('%Y%m%d', datetime(time, 'unixepoch', '$tzOffset seconds')) as date FROM processed WHERE user = '$user' AND stopped IS NULL UNION ALL SELECT title, user, platform, time, stopped, ip_address, xml, paused_counter, strftime('%Y%m%d', datetime(time, 'unixepoch', '$tzOffset seconds')) as date FROM ".$plexWatchDbTable." WHERE user = '$user' ORDER BY time DESC") or die ("Failed to access plexWatch database. Please check your settings.");
 	}else if ($plexWatch['userHistoryGrouping'] == "no") {
-		$results = $db->query("SELECT title, user, platform, time, stopped, ip_address, xml, paused_counter, strftime('%Y%m%d', datetime(time, 'unixepoch', 'localtime')) as date FROM ".$plexWatchDbTable." WHERE user = '$user' ORDER BY time DESC") or die ("Failed to access plexWatch database. Please check your settings.");
+		$results = $db->query("SELECT title, user, platform, time, stopped, ip_address, xml, paused_counter, strftime('%Y%m%d', datetime(time, 'unixepoch', '$tzOffset seconds')) as date FROM ".$plexWatchDbTable." WHERE user = '$user' ORDER BY time DESC") or die ("Failed to access plexWatch database. Please check your settings.");
 	}
 	
 	echo "<div class='container-fluid'>";
@@ -583,7 +583,7 @@
 			
 		echo "<div class='tab-pane' id='userAddresses'>";
 		
-			$userIpAddressesQuery = $db->query("SELECT time,ip_address,platform,xml, COUNT(ip_address) as play_count, strftime('%Y%m%d', datetime(time, 'unixepoch', 'localtime')) as date FROM processed WHERE user = '$user' GROUP BY ip_address ORDER BY time DESC");
+			$userIpAddressesQuery = $db->query("SELECT time,ip_address,platform,xml, COUNT(ip_address) as play_count, strftime('%Y%m%d', datetime(time, 'unixepoch', '$tzOffset seconds')) as date FROM processed WHERE user = '$user' GROUP BY ip_address ORDER BY time DESC");
 
 			echo "<div class='container-fluid'>";	
 				echo "<div class='row-fluid'>";


### PR DESCRIPTION
Uses php's date('Z') timezone offset instead of sqlite's 'localtime' modifier to allow for consistent time stamps in the case where php's timezone is different than the system's timezone.