### PR TITLE
Update timeago.php

### DIFF
--- a/includes/timeago.php
+++ b/includes/timeago.php
@@ -4,6 +4,7 @@ function TimeAgo($datefrom,$dateto=-1)
 // Defaults and assume if 0 is passed in that
 // its an error rather than the epoch
 
+$datefrom = intval($datefrom);
 if($datefrom<=0) { return "A long time ago"; }
 if($dateto==-1) { $dateto = time(); }
 


### PR DESCRIPTION
This fixes strange values shown in the "Recently Added" area and eliminates hundreds of PHP warnings ("date() expects parameter 2 to be long, object given") in the apache error log.
