### PR TITLE
fix index.php for user count == 0

### DIFF
--- a/index.php
+++ b/index.php
@@ -159,7 +159,11 @@
 							
 							date_default_timezone_set(@date_default_timezone_get());
 							$db = dbconnect();
-							$users = $db->querySingle("SELECT count(DISTINCT user) as users FROM processed") or die ("Failed to access plexWatch database. Please check your settings.");
+							$users = $db->querySingle("SELECT count(DISTINCT user) as users FROM processed");
+							if ($users === false) {
+								die ("Failed to access plexWatch database. Please check your settings.");
+							}
+
 							
 							echo "<li>";
 									echo "<h1>".$users."</h1><h5>Users</h5>";


### PR DESCRIPTION
If $users is equal to 0 after the query, then the original "or die" was triggered, despite 0 being a legitimate value. This was the case the first time I tried using plexWatchWeb, which led to me trying to figure out why I "Failed to access plexWatch database", when everything was actually okay.