### PR TITLE
Make stat names correct

### DIFF
--- a/datafactory/get-library-stats.php
+++ b/datafactory/get-library-stats.php
@@ -13,80 +13,49 @@ if (file_exists($guisettingsFile)) {
 
 
 $plexWatchPmsUrl = "http://".$plexWatch['pmsIp'].":".$plexWatch['pmsHttpPort']."";
+$PMSdieMsg = "<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>";
 
 
 if (!empty($plexWatch['myPlexAuthToken'])) {
-    $myPlexAuthToken = $plexWatch['myPlexAuthToken'];
-    $fileContents = '';
-    if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/status/sessions?X-Plex-Token=".$myPlexAuthToken."")) {
-        $statusSessions = simplexml_load_string($fileContents) or die ("<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>");
-    }
-    $sections = simplexml_load_file("".$plexWatchPmsUrl."/library/sections?X-Plex-Token=".$myPlexAuthToken."") or die ("<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>");
-}else{
+    $myPlexAuthToken = "X-Plex-Token=".$plexWatch['myPlexAuthToken'];
+} else {
     $myPlexAuthToken = '';
-    if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/status/sessions?X-Plex-Token=".$myPlexAuthToken."")) {
-        $statusSessions = simplexml_load_string($fileContents) or die ("<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>");
-    }
-    $sections = simplexml_load_file("".$plexWatchPmsUrl."/library/sections") or die ("<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>");
 }
+
+if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/status/sessions?".$myPlexAuthToken."")) {
+	$statusSessions = simplexml_load_string($fileContents) or die ($PMSdieMsg);
+}
+$sections = simplexml_load_file("".$plexWatchPmsUrl."/library/sections?".$myPlexAuthToken."") or die ($PMSdieMsg);
+
 
 echo "<ul>";
 
 foreach ($sections->children() as $section) {
+	if (($section['type'] == "movie") || ($section['type'] == "artist"))  {
+		$sectionDetails = simplexml_load_file("".$plexWatchPmsUrl."/library/sections/".$section['key']."/all?X-Plex-Container-Start=0&X-Plex-Container-Size=0&".$myPlexAuthToken."") or die ($PMSdieMsg);
 
-    if (!empty($plexWatch['myPlexAuthToken'])) {
-        if ($section['type'] == "movie") {
-            $sectionDetails = simplexml_load_file("".$plexWatchPmsUrl."/library/sections/".$section['key']."/all?type=1&sort=addedAt:desc&X-Plex-Container-Start=0&X-Plex-Container-Size=1&X-Plex-Token=".$myPlexAuthToken."") or die ("<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>");
+		echo "<li>";
+		echo "<h1>".$sectionDetails['totalSize']."</h1><h5>".$section['title']."</h5>";
+		echo "</li>";
+	} else if ($section['type'] == "show") {
+		$sectionDetails = simplexml_load_file("".$plexWatchPmsUrl."/library/sections/".$section['key']."/all?type=2&X-Plex-Container-Start=0&X-Plex-Container-Size=0&".$myPlexAuthToken."") or die ($PMSdieMsg);
+		$tvEpisodeCount = simplexml_load_file("".$plexWatchPmsUrl."/library/sections/".$section['key']."/all?type=4&X-Plex-Container-Start=0&X-Plex-Container-Size=0&".$myPlexAuthToken."") or die ($PMSdieMsg);
 
-            echo "<li>";
-            echo "<h1>".$sectionDetails['totalSize']."</h1><h5>".$section['title']."</h5>";
-            echo "</li>";
-        }else if ($section['type'] == "show") {
-            $sectionDetails = simplexml_load_file("".$plexWatchPmsUrl."/library/sections/".$section['key']."/all?type=2&sort=addedAt:desc&X-Plex-Container-Start=0&X-Plex-Container-Size=1&X-Plex-Token=".$myPlexAuthToken."") or die ("<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>");
-            $tvEpisodeCount = simplexml_load_file("".$plexWatchPmsUrl."/library/sections/".$section['key']."/all?type=4&X-Plex-Container-Start=0&X-Plex-Container-Size=1&X-Plex-Token=".$myPlexAuthToken."") or die ("<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>");
-
-            echo "<li>";
-            echo "<h1>".$sectionDetails['totalSize']."</h1><h5>".$section['title']."</h5>";
-            echo "</li>";
-            echo "<li>";
-            echo "<h1>".$tvEpisodeCount['totalSize']."</h1><h5>TV Episodes</h5>";
-            echo "</li>";
-        }else if ($section['type'] == "artist") {
-            $sectionDetails = simplexml_load_file("".$plexWatchPmsUrl."/library/sections/".$section['key']."/all?sort=addedAt:desc&X-Plex-Container-Start=0&X-Plex-Container-Size=1&X-Plex-Token=".$myPlexAuthToken."") or die ("<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>");
-
-            echo "<li>";
-            echo "<h1>".$sectionDetails['totalSize']."</h1><h5>".$section['title']."</h5>";
-            echo "</li>";
-
-        }
-    }else{
-        if ($section['type'] == "movie") {
-            $sectionDetails = simplexml_load_file("".$plexWatchPmsUrl."/library/sections/".$section['key']."/all?type=1&sort=addedAt:desc&X-Plex-Container-Start=0&X-Plex-Container-Size=1") or die ("<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>");
-
-            echo "<li>";
-            echo "<h1>".$sectionDetails['totalSize']."</h1><h5>".$section['title']."</h5>";
-            echo "</li>";
-        }else if ($section['type'] == "show") {
-            $sectionDetails = simplexml_load_file("".$plexWatchPmsUrl."/library/sections/".$section['key']."/all?type=2&sort=addedAt:desc&X-Plex-Container-Start=0&X-Plex-Container-Size=1") or die ("<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>");
-            $tvEpisodeCount = simplexml_load_file("".$plexWatchPmsUrl."/library/sections/".$section['key']."/all?type=4&X-Plex-Container-Start=0&X-Plex-Container-Size=1") or die ("<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>");
-
-            echo "<li>";
-            echo "<h1>".$sectionDetails['totalSize']."</h1><h5>".$section['title']."</h5>";
-            echo "</li>";
-            echo "<li>";
-            echo "<h1>".$tvEpisodeCount['totalSize']."</h1><h5>TV Episodes</h5>";
-            echo "</li>";
-        }else if ($section['type'] == "artist") {
-            $sectionDetails = simplexml_load_file("".$plexWatchPmsUrl."/library/sections/".$section['key']."/all?sort=addedAt:desc&X-Plex-Container-Start=0&X-Plex-Container-Size=1") or die ("<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>");
-
-            echo "<li>";
-            echo "<h1>".$sectionDetails['totalSize']."</h1><h5>".$section['title']."</h5>";
-            echo "</li>";
-        }
-    }
+		// Cut ' Shows' from the end of the title
+		if (strlen($section['title']) > 6 && strcmp(' Shows', substr($section['title'], -6)) == 0) {
+			$title = substr($section['title'], 0, -6);
+		} else {
+			$title = $section['title'];
+		}
+		echo "<li>";
+		echo "<h1>".$sectionDetails['totalSize']."</h1><h5>".$title." Shows</h5>";
+		echo "</li>";
+		echo "<li>";
+		echo "<h1>".$tvEpisodeCount['totalSize']."</h1><h5>".$title." Episodes</h5>";
+		echo "</li>";
+	}
 }
 
-date_default_timezone_set(@date_default_timezone_get());
 $db = dbconnect();
 $users = $db->querySingle("SELECT count(DISTINCT user) as users FROM processed") or die ("Failed to access plexWatch database. Please check your settings.");
 if ($users === false) {
@@ -96,6 +65,5 @@ if ($users === false) {
 echo "<li>";
 echo "<h1>".$users."</h1><h5>Users</h5>";
 echo "</li>";
-
 
 echo "</ul>";


### PR DESCRIPTION
Simple fix of the statistic names. Appends ' Shows' on the end of any TV
section except for 'TV Shows'. Adds the section name to the Episodes
listing.
Optimization of the code, removed a lot of duplication.

Fixes https://github.com/ecleese/plexWatchWeb/issues/104 in the most simplistic way.