### PR TITLE
Plex HTTPS support

### DIFF
--- a/charts.php
+++ b/charts.php
@@ -9,8 +9,7 @@ if (file_exists($guisettingsFile)) {
 	return;
 }
 
-$plexWatchPmsUrl = 'http://' . $plexWatch['pmsIp'] . ':' .
-	$plexWatch['pmsHttpPort'];
+$plexWatchPmsUrl = getPmsURL();
 
 if (!empty($plexWatch['myPlexAuthToken'])) {
 	$myPlexAuthToken = '?X-Plex-Token=' . $plexWatch['myPlexAuthToken'];

--- a/charts.php
+++ b/charts.php
@@ -9,16 +9,7 @@ if (file_exists($guisettingsFile)) {
 	return;
 }
 
-$plexWatchPmsUrl = getPmsURL();
-
-if (!empty($plexWatch['myPlexAuthToken'])) {
-	$myPlexAuthToken = '?X-Plex-Token=' . $plexWatch['myPlexAuthToken'];
-} else {
-	$myPlexAuthToken = '';
-}
-
-if ($fileContents = file_get_contents($plexWatchPmsUrl .
-		'/status/sessions' . $myPlexAuthToken)) {
+if ($fileContents = getPMSData('/status/sessions')) {
 	$statusSessions = simplexml_load_string($fileContents);
 	if ($statusSessions === false) {
 		$error_msg = 'Failed to access Plex Media Server. Please check your settings.';

--- a/charts.php
+++ b/charts.php
@@ -20,9 +20,12 @@ if (!empty($plexWatch['myPlexAuthToken'])) {
 
 if ($fileContents = file_get_contents($plexWatchPmsUrl .
 		'/status/sessions' . $myPlexAuthToken)) {
-	$msg = 'Failed to access Plex Media Server. Please check your settings.';
-	$statusSessions = simplexml_load_string($fileContents) or
-		trigger_error($msg, E_USER_ERROR);
+	$statusSessions = simplexml_load_string($fileContents);
+	if ($statusSessions === false) {
+		$error_msg = 'Failed to access Plex Media Server. Please check your settings.';
+		echo '<p>' . $error_msg . '</p>';
+		trigger_error($error_msg, E_USER_ERROR);
+	}
 }
 
 $database = dbconnect();
@@ -34,8 +37,9 @@ function printTop10($query, $type = null) {
 	global $database;
 	$results = $database->query($query);
 	if ($results === false) {
-		$msg = 'There was a problem running "' . $query . '".';
-		trigger_error($msg, E_USER_ERROR);
+		$error_msg = 'There was a problem running "' . $query . '".';
+		echo '<p>' . $error_msg . '</p>';
+		trigger_error($error_msg, E_USER_ERROR);
 	}
 	$imgSize = '&width=100&height=149';
 

--- a/datafactory/get-library-stats.php
+++ b/datafactory/get-library-stats.php
@@ -16,7 +16,7 @@ if ($users === false) {
 	die ("Failed to access plexWatch database. Please check your settings.");
 }
 
-$plexWatchPmsUrl = "http://".$plexWatch['pmsIp'].":".$plexWatch['pmsHttpPort']."";
+$plexWatchPmsUrl = getPmsURL();
 $PMSdieMsg = "<div class=\"alert alert-warning \">Failed to access Plex Media Server. Please check your settings.</div>";
 
 if (!empty($plexWatch['myPlexAuthToken'])) {

--- a/datafactory/get-library-stats.php
+++ b/datafactory/get-library-stats.php
@@ -25,19 +25,24 @@ if (!empty($plexWatch['myPlexAuthToken'])) {
 	$myPlexAuthToken = '';
 }
 
-if ($fileContents = file_get_contents("".$plexWatchPmsUrl."/status/sessions?".$myPlexAuthToken."")) {
-	$statusSessions = simplexml_load_string($fileContents) or die ($PMSdieMsg);
-}
-$sections = simplexml_load_file("".$plexWatchPmsUrl."/library/sections?".$myPlexAuthToken."") or die ($PMSdieMsg);
-
+$sessionsData = getPmsData('/status/sessions');
+$statusSessions = simplexml_load_string($sessionsData) or die ($PMSdieMsg);
+$sectionsData = getPmsData('/library/sections');
+$sections = simplexml_load_string($sectionsData) or die ($PMSdieMsg);
 echo "<ul>";
 	foreach ($sections->children() as $section) {
 		if (($section['type'] == "movie") || ($section['type'] == "artist"))  {
-			$sectionDetails = simplexml_load_file("".$plexWatchPmsUrl."/library/sections/".$section['key']."/all?X-Plex-Container-Start=0&X-Plex-Container-Size=0&".$myPlexAuthToken."") or die ($PMSdieMsg);
+			$sectionDetails = simplexml_load_string(getPmsData('/library/sections/' .
+				$section['key'] . '/all?X-Plex-Container-Start=0&X-Plex-Container-Size=0'))
+				or die ($PMSdieMsg);
 			echo "<li><h1>".$sectionDetails['totalSize']."</h1><h5>".$section['title']."</h5></li>";
 		} else if ($section['type'] == "show") {
-			$sectionDetails = simplexml_load_file("".$plexWatchPmsUrl."/library/sections/".$section['key']."/all?type=2&X-Plex-Container-Start=0&X-Plex-Container-Size=0&".$myPlexAuthToken."") or die ($PMSdieMsg);
-			$tvEpisodeCount = simplexml_load_file("".$plexWatchPmsUrl."/library/sections/".$section['key']."/all?type=4&X-Plex-Container-Start=0&X-Plex-Container-Size=0&".$myPlexAuthToken."") or die ($PMSdieMsg);
+			$sectionDetails = simplexml_load_string(getPmsData('/library/sections/' .
+				$section['key'] . '/all?type=2&X-Plex-Container-Start=0&X-Plex-Container-Size=0'))
+				or die ($PMSdieMsg);
+			$tvEpisodeCount = simplexml_load_string(getPmsData('/library/sections/' .
+				$section['key'] . '/all?type=4&X-Plex-Container-Start=0&X-Plex-Container-Size=0'))
+				or die ($PMSdieMsg);
 
 			// Cut ' Shows' from the end of the title
 			if (strlen($section['title']) > 6 && strcmp(' Shows', substr($section['title'], -6)) == 0) {

--- a/datafactory/get-user-ip-stats.php
+++ b/datafactory/get-user-ip-stats.php
@@ -22,17 +22,26 @@ if (isset($_POST['user'])) {
 }
 
 $plexWatchDbTable = dbTable('user');
-$userIpAddressesQuery = $db->query("SELECT time,ip_address,platform,xml, COUNT(ip_address) as play_count, strftime('%Y%m%d', datetime(time, 'unixepoch', 'localtime')) as date FROM processed WHERE user = '$user' GROUP BY ip_address ORDER BY time DESC");
+$userIpAddressesQuery = $db->query("SELECT time, ip_address, platform, xml," .
+		"COUNT(ip_address) as play_count, " .
+		"strftime('%Y%m%d', datetime(time, 'unixepoch', 'localtime')) as date " .
+	"FROM processed " .
+	"WHERE user = '$user' " .
+	"GROUP BY ip_address " .
+	"ORDER BY time DESC");
 $nrow = Array();
 $i = 0;
 while ($userIpAddresses = $userIpAddressesQuery->fetchArray()) {
 	if (!empty($userIpAddresses['ip_address'])) {
-		if (strpos($userIpAddresses['ip_address'], "192.168" ) === 0) {
-		} else if (strpos($userIpAddresses['ip_address'], "10." ) === 0) {
-		} else if (strpos($userIpAddresses['ip_address'], "172.16" ) === 0) { //need a solution to check for 17-31
+		if (strpos($userIpAddresses['ip_address'], "192.168" ) === false) {
+		} else if (strpos($userIpAddresses['ip_address'], "10." ) === false) {
+		} else if (strpos($userIpAddresses['ip_address'], "172.16" ) === false) {
+			//need a solution to check for 17-31
 		} else {
-			$userIpAddressesUrl = "http://www.geoplugin.net/xml.gp?ip=".$userIpAddresses['ip_address']."";
-			$userIpAddressesData = simplexml_load_file($userIpAddressesUrl) or die ("<div class=\"alert alert-warning \">Cannot access http://www.geoplugin.net.</div>");
+			$userIpAddressesUrl = "http://www.geoplugin.net/xml.gp?ip=" .
+				$userIpAddresses['ip_address'];
+			$userIpAddressesData = simplexml_load_file($userIpAddressesUrl)
+				or die ("<div class=\"alert alert-warning \">Cannot access http://www.geoplugin.net.</div>");
 			$nrow[$i][] = $userIpAddresses['time'];
 			$nrow[$i][] = $userIpAddresses['ip_address'];
 			$nrow[$i][] = $userIpAddresses['play_count'];
@@ -42,8 +51,11 @@ while ($userIpAddresses = $userIpAddressesQuery->fetchArray()) {
 				$nrow[$i][] = "n/a";
 				$nrow[$i][] = "";
 			} else {
-				$nrow[$i][] = $userIpAddressesData->geoplugin_city.", ".$userIpAddressesData->geoplugin_region;
-				$nrow[$i][] = "https://maps.google.com/maps?q=".urlencode($userIpAddressesData->geoplugin_city.", ".$userIpAddressesData->geoplugin_region);
+				$nrow[$i][] = $userIpAddressesData->geoplugin_city . ", " .
+					$userIpAddressesData->geoplugin_region;
+				$nrow[$i][] = "https://maps.google.com/maps?q=" .
+					urlencode($userIpAddressesData->geoplugin_city . ", " .
+						$userIpAddressesData->geoplugin_region);
 			}
 			$i++;
 		}

--- a/datafactory/get-user-recently-watched.php
+++ b/datafactory/get-user-recently-watched.php
@@ -10,7 +10,7 @@ if (file_exists($guisettingsFile)) {
 	exit;
 }
 
-$plexWatchPmsUrl = "http://".$plexWatch['pmsIp'].":".$plexWatch['pmsHttpPort']."";
+$plexWatchPmsUrl = getPmsURL();
 
 $db = dbconnect();
 

--- a/datafactory/get-user-recently-watched.php
+++ b/datafactory/get-user-recently-watched.php
@@ -10,33 +10,31 @@ if (file_exists($guisettingsFile)) {
 	exit;
 }
 
-$plexWatchPmsUrl = getPmsURL();
-
 $db = dbconnect();
 
 if (isset($_POST['user'])) {
 	$user = $db->escapeString($_POST['user']);
 } else {
 	error_log('PlexWatchWeb :: POST parameter "user" not found.');
-	echo "user field is required.";
+	echo "User field is required.";
 	exit;
 }
 
 $plexWatchDbTable = dbTable('user');
-$recentlyWatchedResults = $db->query("SELECT title, user, platform, time, stopped, ip_address, xml, paused_counter FROM ".$plexWatchDbTable." WHERE user = '$user' ORDER BY time DESC LIMIT 10");
+$recentlyWatchedResults = $db->query("SELECT title, user, platform, time, " .
+		"stopped, ip_address, xml, paused_counter " .
+	"FROM " . $plexWatchDbTable . " " .
+	"WHERE user = '$user' " .
+	"ORDER BY time DESC " .
+	"LIMIT 10");
 
 echo "<ul class='dashboard-recent-media'>";
 // Run through each feed item
 while ($recentlyWatchedRow = $recentlyWatchedResults->fetchArray()) {
 	$request_url = $recentlyWatchedRow['xml'];
 	$recentXml = simplexml_load_string($request_url);
-	if (!empty($plexWatch['myPlexAuthToken'])) {
-		$myPlexAuthToken = "?X-Plex-Token=" . $plexWatch['myPlexAuthToken'];
-	} else {
-		$myPlexAuthToken = '';
-	}
-	$recentMetadata = $plexWatchPmsUrl."/library/metadata/".$recentXml['ratingKey'].$myPlexAuthToken;
-	if ($recentThumbUrlRequest = @simplexml_load_file($recentMetadata)) {
+	$recentMetadata = getPmsData('/library/metadata/' . $recentXml['ratingKey']);
+	if ($recentThumbUrlRequest = simplexml_load_string($recentMetadata)) {
 		$thumbUrl = 'images/poster.png';
 		if ($recentXml['type'] == "episode") {
 			$recentThumbUrl = $recentThumbUrlRequest->Video['parentThumb']."&width=136&height=280";

--- a/includes/ConfigClass.php
+++ b/includes/ConfigClass.php
@@ -3,6 +3,11 @@ ini_set("auto_detect_line_endings", true);
 class ConfigClass {
 	public static function read($filename) {
 		$config_array = array();
+		if (!file_exists($filename)) {
+			$error_msg = 'Attempted to read non-existent settings!';
+			echo '<p>' . $error_msg . '</p>';
+			trigger_error($error_msg, E_USER_ERROR);
+		}
 		$handle = fopen($filename, "r");
 		if ($handle) {
 			while (($line = fgets($handle)) !== false) {

--- a/includes/current_activity.php
+++ b/includes/current_activity.php
@@ -1,7 +1,7 @@
 <?php
 require_once(dirname(__FILE__) . '/../config/config.php');
 
-$plexWatchPmsUrl = "http://".$plexWatch['pmsIp'].":".$plexWatch['pmsHttpPort']."";
+$plexWatchPmsUrl = getPmsURL();
 
 $fileContents = '';
 

--- a/includes/current_activity.php
+++ b/includes/current_activity.php
@@ -1,17 +1,7 @@
 <?php
 require_once(dirname(__FILE__) . '/../config/config.php');
 
-$plexWatchPmsUrl = getPmsURL();
-
-$fileContents = '';
-
-if (!empty($plexWatch['myPlexAuthToken'])) {
-	$myPlexAuthToken = '?X-Plex-Token='.$plexWatch['myPlexAuthToken'];
-} else {
-	$myPlexAuthToken = '';
-}
-$fileContents = file_get_contents("" . $plexWatchPmsUrl .
-	"/status/sessions" . $myPlexAuthToken) or
+$fileContents = getPmsData('/status/sessions') or
 	die ("<div class='alert alert-warning'>Failed to access Plex Media Server. " .
 		"Please check your settings.</div>");
 $statusSessions = simplexml_load_string($fileContents) or die ("Failed to parse Plex response.");

--- a/includes/current_activity_header.php
+++ b/includes/current_activity_header.php
@@ -1,16 +1,7 @@
 <?php
 require_once(dirname(__FILE__) . '/../config/config.php');
 
-$plexWatchPmsUrl = getPmsURL();
-$fileContents = '';
-
-if (!empty($plexWatch['myPlexAuthToken'])) {
-	$myPlexAuthToken = '?X-Plex-Token='.$plexWatch['myPlexAuthToken'];
-} else {
-	$myPlexAuthToken = '';
-}
-$fileContents = file_get_contents("" . $plexWatchPmsUrl .
-	"/status/sessions" . $myPlexAuthToken) or
+$fileContents = getPmsData('/status/sessions') or
 	die ("<div class='alert alert-warning'>Failed to access Plex Media Server. " .
 		"Please check your settings.</div>");
 $statusSessions = simplexml_load_string($fileContents) or die ("Failed to parse Plex response.");

--- a/includes/current_activity_header.php
+++ b/includes/current_activity_header.php
@@ -1,7 +1,7 @@
 <?php
 require_once(dirname(__FILE__) . '/../config/config.php');
 
-$plexWatchPmsUrl = "http://".$plexWatch['pmsIp'].":".$plexWatch['pmsHttpPort']."";
+$plexWatchPmsUrl = getPmsURL();
 $fileContents = '';
 
 if (!empty($plexWatch['myPlexAuthToken'])) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -50,16 +50,20 @@ function dbconnect() {
 	global $plexWatch;
 
 	if (!class_exists('SQLite3')) {
-		trigger_error('<div class="alert alert-warning ">' .
-				'php5-sqlite is not installed. Please install this requirement and ' .
-				'restart your webserver before continuing.' .
-			'</div>',
-			E_USER_ERROR);
+		$error_msg = 'php5-sqlite is not installed. Please install this ' .
+			'requirement and restart your webserver before continuing.';
+		echo '<div class="alert alert-warning ">' . $error_msg . '</div>';
+		trigger_error($error_msg, E_USER_ERROR);
 	}
-
-	$database = new SQLite3($plexWatch['plexWatchDb'], SQLITE3_OPEN_READONLY);
-	$database->busyTimeout(10 * 1000);
-	return $database;
+	try {
+		$database = new SQLite3($plexWatch['plexWatchDb'], SQLITE3_OPEN_READONLY);
+		$database->busyTimeout(10 * 1000);
+		return $database;
+	} catch (Exception $exception) {
+		$error_msg = 'There was an error connecting to the database!';
+		echo '<p>' . $error_msg . '</p>';
+		trigger_error($error_msg, E_USER_ERROR);
+	}
 }
 
 /* DBtable -- processed or grouped */
@@ -149,19 +153,18 @@ function getPlatformImage($xml) {
 		return "images/platforms/xbox.png";
 	} else if (strstr($xml->Player['platform'], 'Samsung')) {
 		return "images/platforms/samsung.png";
-	}else if(strstr($xml->Player['platform'], 'Opera')) {
+	} else if(strstr($xml->Player['platform'], 'Opera')) {
 		return "images/platforms/opera.png";
-	}else if(strstr($xml->Player['platform'], 'KODI')) {
+	} else if(strstr($xml->Player['platform'], 'KODI')) {
 		return "images/platforms/kodi.png";
-	}else if(strstr($xml->Player['platform'], 'Mystery 3')) {
+	} else if(strstr($xml->Player['platform'], 'Mystery 3')) {
 		return "images/platforms/playstation.png";
-	}else if(strstr($xml->Player['platform'], 'Mystery 4')) {
-		return "images/platforms/playstation.png";			
-				
-	}else if (empty($xml->Player['platform'])) {
+	} else if(strstr($xml->Player['platform'], 'Mystery 4')) {
+		return "images/platforms/playstation.png";
+	} else if (empty($xml->Player['platform'])) {
 		if (strstr($xml->Player['title'], 'Apple')) {
 			return "images/platforms/atv.png";
-		} else if(stristr($xml->Player['title'], 'Plex for Sony')) {
+		} else if (stristr($xml->Player['title'], 'Plex for Sony')) {
 			return "images/platforms/playstation.png";
 		} else if (preg_match("/TV [a-z][a-z]\d\d[a-z]\d\d\d\d/i",
 				$xml->Player['title'])) {

--- a/includes/img.php
+++ b/includes/img.php
@@ -14,7 +14,9 @@ $imgReq = '';
 if (isset($_GET['img'])) {
 	$imgReq = $_GET['img'];
 } else {
-	trigger_error('No image to retrieve specified.', E_USER_ERROR);
+	$error_msg = 'No image to retrieve specified.';
+	echo '<p>' . $error_msg . '</p>';
+	trigger_error($error_msg, E_USER_ERROR);
 }
 $url = $plexWatchPmsUrl .
 	'/photo/:/transcode' . $myPlexAuthToken .
@@ -22,7 +24,9 @@ $url = $plexWatchPmsUrl .
 
 $img = file_get_contents($url);
 if ($img === false) {
-	trigger_error("Failed to retrieve \"$url\"", E_USER_ERROR);
+	$error_msg = 'Failed to retrieve "' . $url . '"';
+	echo '<p>' . $error_msg . '</p>';
+	trigger_error($error_msg, E_USER_ERROR);
 }
 foreach ($http_response_header as $value) {
 	if (preg_match('/^Content-Type:/i', $value)) {

--- a/includes/img.php
+++ b/includes/img.php
@@ -1,8 +1,7 @@
 <?php
 require_once(dirname(__FILE__) . '/../config/config.php');
 
-$plexWatchPmsUrl = 'http://' . $plexWatch['pmsIp'] . ':' .
-	$plexWatch['pmsHttpPort'];
+$plexWatchPmsUrl = getPmsURL();
 
 if (!empty($plexWatch['myPlexAuthToken'])) {
 	$myPlexAuthToken = '?X-Plex-Token=' . $plexWatch['myPlexAuthToken'];

--- a/includes/process_settings.php
+++ b/includes/process_settings.php
@@ -3,7 +3,10 @@ session_start();
 require_once(dirname(__FILE__) . '/ConfigClass.php');
 
 $config = new ConfigClass();
-$existing_config = $config::read('../config/config.php');
+$config_file = '../config/config.php';
+if (file_exists($config_file)) {
+	$existing_config = $config::read($config_file);
+}
 
 $dateFormat = "\$plexWatch['dateFormat'] = '".$_POST['dateFormat']."';";
 $timeFormat = "\$plexWatch['timeFormat'] = '".$_POST['timeFormat']."';";
@@ -43,17 +46,19 @@ if (!isset($_POST['chartsGrouping'])) {
 }
 
 //combine all data into one variable
-$data = "$dateFormat\r$timeFormat\r$pmsIp\r$pmsHttpPort\r$plexWatchDb\r$myPlexUser\r$myPlexPass\r$globalHistoryGrping\r$userHistoryGrping\r$chartsGrping";
+$data = $dateFormat . PHP_EOL . $timeFormat . PHP_EOL . $pmsIp . PHP_EOL .
+	$pmsHttpPort . PHP_EOL . $plexWatchDb . PHP_EOL . $myPlexUser . PHP_EOL .
+	$myPlexPass . PHP_EOL . $globalHistoryGrping . PHP_EOL . $userHistoryGrping .
+	PHP_EOL . $chartsGrping;
 
-$file = "../config/config.php";
 $func_file = dirname(dirname(__FILE__)) . '/includes/functions.php';
 
 //write data to config.php file
-$fp = fopen($file, "w+") or die("Cannot open file $file.");
-fwrite($fp, "<?php\r\r") or die("Cannot write to file $file.");
-fwrite($fp, "\nrequire_once '$func_file';\n") or die("Cannot write to file $file.");
-fwrite($fp, $data) or die("Cannot write to file $file.");
-fwrite($fp, "\r\r?>") or die("Cannot write to file $file.");
+$fp = fopen($config_file, "w+") or die("Cannot open file $config_file.");
+fwrite($fp, "<?php" . PHP_EOL . PHP_EOL) or die("Cannot write to file $config_file.");
+fwrite($fp, PHP_EOL . "require_once '$func_file';" . PHP_EOL) or die("Cannot write to file $config_file.");
+fwrite($fp, $data) or die("Cannot write to file $config_file.");
+fwrite($fp, PHP_EOL . PHP_EOL . "?>") or die("Cannot write to file $config_file.");
 fclose($fp);
 
 sleep(1);
@@ -63,14 +68,17 @@ require_once(dirname(__FILE__) . '/myplex.php');
 $myPlexToken = "\$plexWatch['myPlexAuthToken'] = '".$myPlexAuthToken."';";
 
 //include authentication code in saved data
-$data = "$dateFormat\r$timeFormat\r$pmsIp\r$pmsHttpPort\r$plexWatchDb\r$myPlexUser\r$myPlexPass\r$myPlexToken\r$globalHistoryGrping\r$userHistoryGrping\r$chartsGrping";
+$data = $dateFormat . PHP_EOL . $timeFormat . PHP_EOL . $pmsIp . PHP_EOL .
+	$pmsHttpPort . PHP_EOL . $plexWatchDb . PHP_EOL . $myPlexUser . PHP_EOL .
+	$myPlexPass . PHP_EOL . $myPlexToken . PHP_EOL . $globalHistoryGrping .
+	PHP_EOL . $userHistoryGrping . PHP_EOL . $chartsGrping;
 
 //rewrite data to config.php
-$fp = fopen($file, "w+") or die("Cannot open file $file.");
-fwrite($fp, "<?php\r\r") or die("Cannot write to file $file.");
-fwrite($fp, "\nrequire_once '$func_file';\n") or die("Cannot write to file $file.");
-fwrite($fp, $data) or die("Cannot write to file $file.");
-fwrite($fp, "\r\r?>") or die("Cannot write to file $file.");
+$fp = fopen($config_file, "w+") or die("Cannot open file $config_file.");
+fwrite($fp, "<?php" . PHP_EOL . PHP_EOL) or die("Cannot write to file $config_file.");
+fwrite($fp, PHP_EOL . "require_once '$func_file';" . PHP_EOL) or die("Cannot write to file $config_file.");
+fwrite($fp, $data) or die("Cannot write to file $config_file.");
+fwrite($fp, PHP_EOL . PHP_EOL . "?>") or die("Cannot write to file $config_file.");
 fclose($fp);
 
 // check if an error was found - if there was, send the user back to the form
@@ -79,5 +87,5 @@ if (!empty($errorCode)) {
 }
 
 // send the user back to the form
-header("Location: ../settings.php?s=".urlencode("Settings saved.")); exit;
+header('Location: ../settings.php?s='.urlencode('Settings saved.')); exit;
 ?>

--- a/includes/process_settings.php
+++ b/includes/process_settings.php
@@ -8,13 +8,16 @@ if (file_exists($config_file)) {
 	$existing_config = $config::read($config_file);
 }
 
+if (!file_exists($_POST['plexWatchDb'])) {
+	haveError("Specified DB file doesn't exist!");
+}
+$plexWatchDb = "\$plexWatch['plexWatchDb'] = '".$_POST['plexWatchDb']."';";
+
 $dateFormat = "\$plexWatch['dateFormat'] = '".$_POST['dateFormat']."';";
 $timeFormat = "\$plexWatch['timeFormat'] = '".$_POST['timeFormat']."';";
 
 $pmsIp = "\$plexWatch['pmsIp'] = '".$_POST['pmsIp']."';";
 $pmsHttpPort = "\$plexWatch['pmsHttpPort'] = '".$_POST['pmsHttpPort']."';";
-
-$plexWatchDb = "\$plexWatch['plexWatchDb'] = '".$_POST['plexWatchDb']."';";
 
 $myPlexUser = "\$plexWatch['myPlexUser'] = '".$_POST['myPlexUser']."';";
 if (isset($_POST['myPlexPass']) && $_POST['myPlexPass'] !== '') {
@@ -27,21 +30,18 @@ if (isset($_POST['myPlexPass']) && $_POST['myPlexPass'] !== '') {
 	}
 }
 
-if (!isset($_POST['globalHistoryGrouping'])) {
-	$globalHistoryGrping = "\$plexWatch['globalHistoryGrouping'] = 'no';";
-} else if ($_POST['globalHistoryGrouping'] == "yes") {
+$globalHistoryGrping = "\$plexWatch['globalHistoryGrouping'] = 'no';";
+if ($_POST['globalHistoryGrouping'] == "yes") {
 	$globalHistoryGrping = "\$plexWatch['globalHistoryGrouping'] = 'yes';";
 }
 
-if (!isset($_POST['userHistoryGrouping'])) {
-	$userHistoryGrping = "\$plexWatch['userHistoryGrouping'] = 'no';";
-} else if ($_POST['userHistoryGrouping'] == "yes") {
+$userHistoryGrping = "\$plexWatch['userHistoryGrouping'] = 'no';";
+if ($_POST['userHistoryGrouping'] == "yes") {
 	$userHistoryGrping = "\$plexWatch['userHistoryGrouping'] = 'yes';";
 }
 
-if (!isset($_POST['chartsGrouping'])) {
-	$chartsGrping = "\$plexWatch['chartsGrouping'] = 'no';";
-} else if ($_POST['chartsGrouping'] == "yes") {
+$chartsGrping = "\$plexWatch['chartsGrouping'] = 'no';";
+if ($_POST['chartsGrouping'] == "yes") {
 	$chartsGrping = "\$plexWatch['chartsGrouping'] = 'yes';";
 }
 
@@ -54,11 +54,11 @@ $data = $dateFormat . PHP_EOL . $timeFormat . PHP_EOL . $pmsIp . PHP_EOL .
 $func_file = dirname(dirname(__FILE__)) . '/includes/functions.php';
 
 //write data to config.php file
-$fp = fopen($config_file, "w+") or die("Cannot open file $config_file.");
-fwrite($fp, "<?php" . PHP_EOL . PHP_EOL) or die("Cannot write to file $config_file.");
-fwrite($fp, PHP_EOL . "require_once '$func_file';" . PHP_EOL) or die("Cannot write to file $config_file.");
-fwrite($fp, $data) or die("Cannot write to file $config_file.");
-fwrite($fp, PHP_EOL . PHP_EOL . "?>") or die("Cannot write to file $config_file.");
+$fp = fopen($config_file, "w+") or haveError("Cannot open file $config_file.");
+fwrite($fp, "<?php" . PHP_EOL . PHP_EOL) or haveError("Cannot write to file $config_file.");
+fwrite($fp, PHP_EOL . "require_once '$func_file';" . PHP_EOL) or haveError("Cannot write to file $config_file.");
+fwrite($fp, $data) or haveError("Cannot write to file $config_file.");
+fwrite($fp, PHP_EOL . PHP_EOL . "?>") or haveError("Cannot write to file $config_file.");
 fclose($fp);
 
 sleep(1);
@@ -74,18 +74,19 @@ $data = $dateFormat . PHP_EOL . $timeFormat . PHP_EOL . $pmsIp . PHP_EOL .
 	PHP_EOL . $userHistoryGrping . PHP_EOL . $chartsGrping;
 
 //rewrite data to config.php
-$fp = fopen($config_file, "w+") or die("Cannot open file $config_file.");
-fwrite($fp, "<?php" . PHP_EOL . PHP_EOL) or die("Cannot write to file $config_file.");
-fwrite($fp, PHP_EOL . "require_once '$func_file';" . PHP_EOL) or die("Cannot write to file $config_file.");
-fwrite($fp, $data) or die("Cannot write to file $config_file.");
-fwrite($fp, PHP_EOL . PHP_EOL . "?>") or die("Cannot write to file $config_file.");
+$fp = fopen($config_file, "w+") or haveError("Cannot open file $config_file.");
+fwrite($fp, "<?php" . PHP_EOL . PHP_EOL) or haveError("Cannot write to file $config_file.");
+fwrite($fp, PHP_EOL . "require_once '$func_file';" . PHP_EOL) or haveError("Cannot write to file $config_file.");
+fwrite($fp, $data) or haveError("Cannot write to file $config_file.");
+fwrite($fp, PHP_EOL . PHP_EOL . "?>") or haveError("Cannot write to file $config_file.");
 fclose($fp);
 
-// check if an error was found - if there was, send the user back to the form
-if (!empty($errorCode)) {
-	header('Location: ../settings.php?e='.urlencode($errorCode)); exit;
+function haveError($msg) {
+	header('Location: ../settings.php?e=' . urlencode($msg));
+	trigger_error($msg, E_USER_ERROR);
 }
 
-// send the user back to the form
-header('Location: ../settings.php?s='.urlencode('Settings saved.')); exit;
+// Send the user back to the form
+header('Location: ../settings.php?s=' . urlencode('Settings saved.'));
+exit;
 ?>

--- a/includes/recently_added.php
+++ b/includes/recently_added.php
@@ -15,7 +15,7 @@ if (isset($_GET['width'])) {
 	}
 	$containerSize = floor($containerSize);
 }
-$plexWatchPmsUrl = 'http://'.$plexWatch['pmsIp'].':'.$plexWatch['pmsHttpPort'].'';
+$plexWatchPmsUrl = getPmsURL();
 
 if (!empty($plexWatch['myPlexAuthToken'])) {
 	$myPlexAuthToken = '&X-Plex-Token='.$plexWatch['myPlexAuthToken'];

--- a/includes/recently_added.php
+++ b/includes/recently_added.php
@@ -15,16 +15,9 @@ if (isset($_GET['width'])) {
 	}
 	$containerSize = floor($containerSize);
 }
-$plexWatchPmsUrl = getPmsURL();
 
-if (!empty($plexWatch['myPlexAuthToken'])) {
-	$myPlexAuthToken = '&X-Plex-Token='.$plexWatch['myPlexAuthToken'];
-} else {
-	$myPlexAuthToken = '';
-}
-$fileContents = file_get_contents("" . $plexWatchPmsUrl .
-	'/library/recentlyAdded?X-Plex-Container-Start=0&X-Plex-Container-Size=' .
-	$containerSize . $myPlexAuthToken) or
+$fileContents = getPmsData('/library/recentlyAdded?X-Plex-Container-Start=0' .
+	'&X-Plex-Container-Size=' .	$containerSize) or
 	die ("<div class='alert alert-warning'>Failed to access Plex Media Server. " .
 		"Please check your settings.</div>");
 $recentRequest = simplexml_load_string($fileContents);

--- a/info.php
+++ b/info.php
@@ -8,7 +8,7 @@ if (file_exists($guisettingsFile)) {
 	header('Location: settings.php');
 }
 
-$plexWatchPmsUrl = 'http://' . $plexWatch['pmsIp'] . ':' . $plexWatch['pmsHttpPort'];
+$plexWatchPmsUrl = getPmsURL();
 if (!empty($plexWatch['myPlexAuthToken'])) {
 	$myPlexAuthToken = '?X-Plex-Token=' . $plexWatch['myPlexAuthToken'];
 } else {

--- a/info.php
+++ b/info.php
@@ -155,8 +155,10 @@ function seasonMetaData($xml) {
 	$parentInfoUrl = $plexWatchPmsUrl . '/library/metadata/'.
 		$xml->Directory['parentRatingKey'] . $myPlexAuthToken;
 	$parentXml = simplexml_load_string(file_get_contents($parentInfoUrl));
-	if (!$parentXml) {
-		trigger_error('Feed Not Found', E_USER_ERROR);
+	if ($parentXml === false) {
+		$error_msg = 'Feed Not Found';
+		echo '<p>' . $error_msg . '</p>';
+		trigger_error($error_msg, E_USER_ERROR);
 	}
 	$data['xmlArt'] = $xml->Directory['art'];
 	if ($xml->Video['parentThumb']) {
@@ -463,8 +465,10 @@ function printSeasonEpisodes($xml) {
 					$seasonEpisodesUrl = $plexWatchPmsUrl . '/library/metadata/' .
 						$itemId . '/children' . $myPlexAuthToken;
 					$seasonEpisodesXml = simplexml_load_string(file_get_contents($seasonEpisodesUrl));
-					if (!$seasonEpisodesXml) {
-						trigger_error('Feed Not Found', E_USER_ERROR);
+					if ($seasonEpisodesXml === false) {
+						$error_msg = 'Feed Not Found';
+						echo '<p>' . $error_msg . '</p>';
+						trigger_error($error_msg, E_USER_ERROR);
 					}
 					echo '<div class="season-episodes-wrapper">';
 						echo '<ul class="season-episodes-instance">';

--- a/info.php
+++ b/info.php
@@ -9,13 +9,8 @@ if (file_exists($guisettingsFile)) {
 }
 
 $plexWatchPmsUrl = getPmsURL();
-if (!empty($plexWatch['myPlexAuthToken'])) {
-	$myPlexAuthToken = '?X-Plex-Token=' . $plexWatch['myPlexAuthToken'];
-} else {
-	$myPlexAuthToken = '';
-}
 $itemId = intval($_GET['id']);
-$infoUrl = $plexWatchPmsUrl . '/library/metadata/' . $itemId . $myPlexAuthToken;
+$infoPath = '/library/metadata/' . $itemId;
 
 function printMetadata($xml) {
 	$data = &metaDataData($xml);
@@ -149,12 +144,10 @@ function showMetaData($xml) {
 }
 
 function seasonMetaData($xml) {
-	global $plexWatchPmsUrl, $myPlexAuthToken;
 	$data = [];
 	$data['type'] = 'season';
-	$parentInfoUrl = $plexWatchPmsUrl . '/library/metadata/'.
-		$xml->Directory['parentRatingKey'] . $myPlexAuthToken;
-	$parentXml = simplexml_load_string(file_get_contents($parentInfoUrl));
+	$parentInfoPath = '/library/metadata/' . $xml->Directory['parentRatingKey'];
+	$parentXml = simplexml_load_string(getPMSData($parentInfoPath));
 	if ($parentXml === false) {
 		$error_msg = 'Feed Not Found';
 		echo '<p>' . $error_msg . '</p>';
@@ -451,7 +444,7 @@ function printShowWatched($xml) {
 }
 
 function printSeasonEpisodes($xml) {
-	global $plexWatchPmsUrl, $myPlexAuthToken, $itemId;
+	global $itemId;
 	echo '<div class="container-fluid">';
 		echo '<div class="clear"></div>';
 		echo '<div class="row-fluid">';
@@ -462,9 +455,8 @@ function printSeasonEpisodes($xml) {
 							echo'<h3>' . $xml->Directory['title'] . '</h3>';
 						echo '</div>';
 					echo '</div>';
-					$seasonEpisodesUrl = $plexWatchPmsUrl . '/library/metadata/' .
-						$itemId . '/children' . $myPlexAuthToken;
-					$seasonEpisodesXml = simplexml_load_string(file_get_contents($seasonEpisodesUrl));
+					$seasonEpisodesPath = '/library/metadata/' . $itemId . '/children';
+					$seasonEpisodesXml = simplexml_load_string(getPmsData($seasonEpisodesPath));
 					if ($seasonEpisodesXml === false) {
 						$error_msg = 'Feed Not Found';
 						echo '<p>' . $error_msg . '</p>';
@@ -559,7 +551,7 @@ function printSeasonEpisodes($xml) {
 				'<div class="span10 offset1">' .
 					'<h3>This media is no longer available in the Plex Media Server database.</h3>' .
 				'</div></div></div>';
-		$xml = simplexml_load_string(file_get_contents($infoUrl)) or die ($msg);
+		$xml = simplexml_load_string(getPmsData($infoPath)) or die ($msg);
 		if ($xml->Video['type'] == 'episode') {
 			printMetadata($xml);
 			printHistory($xml);

--- a/settings.php
+++ b/settings.php
@@ -610,11 +610,9 @@ function printJSONSupport() {
 					<div class="wellbg">
 						<?php
 						if (!class_exists('SQLite3')) {
-							$error_msg = '<div class="alert alert-warning ">' .
-									'php5-sqlite is not installed. Please install this ' .
-									'requirement and restart your webserver before continuing.' .
-								'</div>';
-							echo $error_msg;
+							$error_msg = 'php5-sqlite is not installed. Please install this ' .
+								'requirement and restart your webserver before continuing.';
+							echo '<div class="alert alert-warning">' . $error_msg . '</div>';
 							trigger_error($error_msg, E_USER_ERROR);
 						}
 						// Check for a successful form post

--- a/settings.php
+++ b/settings.php
@@ -59,6 +59,7 @@ function printVersions() {
 		echo '</div>';
 		echo '<div class="settings-general-info">';
 			echo '<ul>';
+				// FIXME: Version should be specified in the settings
 				echo '<li>plexWatch/Web Version: <strong>v1.7.0 dev</strong></li>';
 				$query = "SELECT version FROM config";
 				$plexWatchVersion = $database->querySingle($query);

--- a/settings.php
+++ b/settings.php
@@ -632,7 +632,7 @@ function printJSONSupport() {
 								'this and try again.' . $errorEnd;
 						}
 						printSettings();
-						if (!file_exists($guisettingsFile)) {
+						if (!file_exists($guisettingsFile) && !isset($_GET['e'])) {
 							printWelcomeModal();
 						}
 						?>

--- a/stats.php
+++ b/stats.php
@@ -126,7 +126,11 @@ $query = "SELECT " .
 		"datetime('now', '-24 hours', 'localtime') " .
 	"GROUP BY strftime('%Y-%m-%d %H', datetime(time, 'unixepoch', 'localtime')) " .
 	"ORDER BY date ASC;";
-$hourlyPlays = $db->query($query) or trigger_error($plexDBDie, E_USER_ERROR);
+$hourlyPlays = $db->query($query);
+if ($hourlyPlays === false) {
+	echo '<p>' . $plexDBDie . '</p>';
+	trigger_error($plexDBDie, E_USER_ERROR);
+}
 $hourlyPlayData = [];
 while ($row = $hourlyPlays->fetchArray()) {
 	$hourlyPlayData[] = ["x"=>$row['date'], "y"=>$row['count']];
@@ -139,7 +143,11 @@ $query = "SELECT " .
 	"GROUP BY strftime('%Y-%m-%d %H', datetime(time, 'unixepoch', 'localtime')) " .
 	"ORDER BY count(*) desc " .
 	"LIMIT 25;";
-$maxhourlyPlays = $db->query($query) or trigger_error($plexDBDie, E_USER_ERROR);
+$maxhourlyPlays = $db->query($query);
+if ($maxhourlyPlays === false) {
+	echo '<p>' . $plexDBDie . '</p>';
+	trigger_error($plexDBDie, E_USER_ERROR);
+}
 $maxhourlyPlayData = [];
 while ($row = $maxhourlyPlays->fetchArray()) {
 	$maxhourlyPlayData[] = ["x"=>$row['date'], "y"=>$row['count']];
@@ -152,7 +160,11 @@ $query = "SELECT " .
 	"GROUP BY date " .
 	"ORDER BY time DESC " .
 	"LIMIT 30;";
-$dailyPlays = $db->query($query) or trigger_error($plexDBDie, E_USER_ERROR);
+$dailyPlays = $db->query($query);
+if ($dailyPlays === false) {
+	echo '<p>' . $plexDBDie . '</p>';
+	trigger_error($plexDBDie, E_USER_ERROR);
+}
 $dailyPlayData = [];
 while ($row = $dailyPlays->fetchArray()) {
 	$dailyPlayData[] = ["x"=>$row['date'], "y"=>$row['count']];
@@ -167,7 +179,11 @@ $query = "SELECT " .
 	"GROUP BY strftime('%Y-%m', datetime(time, 'unixepoch', 'localtime')) " .
 	"ORDER BY date DESC " .
 	"LIMIT 13;";
-$monthlyPlays = $db->query($query) or trigger_error($plexDBDie, E_USER_ERROR);
+$monthlyPlays = $db->query($query);
+if ($monthlyPlays === false) {
+	echo '<p>' . $plexDBDie . '</p>';
+	trigger_error($plexDBDie, E_USER_ERROR);
+}
 $monthlyPlayData = [];
 while ($row = $monthlyPlays->fetchArray()) {
 	$monthlyPlayData[] = ["x"=>$row['date'], "y"=>$row['count']];

--- a/user.php
+++ b/user.php
@@ -85,7 +85,11 @@ if (file_exists($guisettingsFile)) {
 			"ORDER BY time DESC " .
 			"LIMIT 1;";
 		$dieMsg = "Failed to access plexWatch database. Please check your settings.";
-		$userInfo = $db->query($query) or trigger_error($dieMsg, E_USER_ERROR);
+		$userInfo = $db->query($query);
+		if ($userInfo === false) {
+			echo '<p>' . $dieMsg . '</p>';
+			trigger_error($dieMsg, E_USER_ERROR);
+		}
 		?>
 		<div class="container-fluid">
 			<div class="row-fluid">

--- a/users.php
+++ b/users.php
@@ -77,7 +77,11 @@ if (file_exists($guisettingsFile)) {
 						"ORDER BY user " .
 						"COLLATE NOCASE";
 					$dieMsg = "Failed to access plexWatch database. Please check your settings.";
-					$users = $db->query($query) or trigger_error($dieMsg, E_USER_ERROR);
+					$users = $db->query($query);
+					if ($users === false) {
+						echo '<p>' . $dieMsg . '</p>';
+						trigger_error($dieMsg, E_USER_ERROR);
+					}
 					echo '<div class="wellbg">';
 						echo '<table id="usersTable" class="display">';
 							echo '<thead>';


### PR DESCRIPTION
Allows plexWatch/Web to work with a Plex server (> 0.9.12.3) that has secure connections set to "Required". For new installations the method of getting a Plex token has been updated to use the newer plex.tv URL instead of the old my.plexapp.com. The app also properly identifies itself to Plex.