### PR TITLE
PHP 5.3.3 compatibility

### DIFF
--- a/datafactory/get-info-modal.php
+++ b/datafactory/get-info-modal.php
@@ -11,7 +11,7 @@ if (file_exists($guisettingsFile)) {
 }
 
 $itemId = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT,
-	['options'=>['min_range'=>1]]);
+	array('options'=>array('min_range'=>1)));
 if (!isset($itemId) || $itemId === false) {
 	echo "<p>ID field is required.</p>";
 	$error_msg = 'PlexWatchWeb :: POST parameter "id" not found or invalid.';
@@ -27,10 +27,8 @@ if (isset($_POST['table']) &&
 
 $database = dbconnect();
 $query = "SELECT xml FROM :table WHERE id = :id";
-$results = getResults($database, $query, [
-		'table'=>$plexWatchDbTable,
-		'id'=>$itemId
-	]);
+$params = array(':table'=>$plexWatchDbTable, ':id'=>$itemId);
+$results = getResults($database, $query, $params);
 $xml = $results->fetchColumn();
 $xmlfield = simplexml_load_string($xml);
 printStreamDetails($xmlfield);

--- a/datafactory/get-user-ip-stats.php
+++ b/datafactory/get-user-ip-stats.php
@@ -24,8 +24,9 @@ $query = "SELECT time, ip_address, platform, xml," .
 	"WHERE user = :user " .
 	"GROUP BY ip_address " .
 	"ORDER BY time DESC";
-$results = getResults($database, $query, [':user'=>$_POST['user']]);
-$nrow = [];
+$params = array(':user'=>$_POST['user']);
+$results = getResults($database, $query, $params);
+$nrow = array();
 $i = 0;
 while ($row = $results->fetch(PDO::FETCH_ASSOC)) {
 	if (empty($row['ip_address'])) {

--- a/datafactory/get-user-platform-stats.php
+++ b/datafactory/get-user-platform-stats.php
@@ -23,7 +23,8 @@ $query = "SELECT xml, platform, COUNT(platform) as platform_count " .
 	"WHERE user = :user " .
 	"GROUP BY platform " .
 	"ORDER BY platform ASC";
-$platformResults = getResults($database, $query, [':user'=>$_POST['user']]);
+$params = array(':user'=>$_POST['user']);
+$platformResults = getResults($database, $query, $params);
 while ($row = $platformResults->fetch(PDO::FETCH_ASSOC)) {
 	$platformXml = $row['xml'];
 	$platformXmlField = simplexml_load_string($platformXml);

--- a/datafactory/get-user-recently-watched.php
+++ b/datafactory/get-user-recently-watched.php
@@ -23,7 +23,8 @@ $query = "SELECT title, user, platform, time, " .
 	"WHERE user = :user " .
 	"ORDER BY time DESC " .
 	"LIMIT 10";
-$results = getResults($database, $query, [':user'=>$_POST['user']]);
+$params = array(':user'=>$_POST['user']);
+$results = getResults($database, $query, $params);
 $imgSize = '&width=136&height=280';
 
 echo '<ul class="dashboard-recent-media">';

--- a/datafactory/get-user-time-stats.php
+++ b/datafactory/get-user-time-stats.php
@@ -73,32 +73,33 @@ class elapsedTimeResult {
 $plexWatchDbTable = dbTable('user');
 $database = dbconnect();
 $columns = 'time, stopped, paused_counter';
+$params = array(':user'=>$_POST['user']);
 
 $query = "SELECT $columns " .
 	"FROM $plexWatchDbTable " .
 	"WHERE datetime(stopped, 'unixepoch', 'localtime') >= date('now', 'localtime') " .
 	"AND user = :user";
-$results = getResults($database, $query, [':user'=>$_POST['user']]);
+$results = getResults($database, $query, $params);
 $dailyStats = new elapsedTimeResult($results);
 
 $query = "SELECT $columns " .
 	"FROM $plexWatchDbTable " .
 	"WHERE datetime(stopped, 'unixepoch', 'localtime') >= datetime('now', '-7 days', 'localtime') " .
 	"AND user = :user";
-$results = getResults($database, $query, [':user'=>$_POST['user']]);
+$results = getResults($database, $query, $params);
 $weeklyStats = new elapsedTimeResult($results);
 
 $query = "SELECT $columns " .
 	"FROM $plexWatchDbTable " .
 	"WHERE datetime(stopped, 'unixepoch', 'localtime') >= datetime('now', '-30 days', 'localtime') " .
 	"AND user = :user";
-$results = getResults($database, $query, [':user'=>$_POST['user']]);
+$results = getResults($database, $query, $params);
 $monthlyStats = new elapsedTimeResult($results);
 
 $query = "SELECT $columns " .
 	"FROM $plexWatchDbTable " .
 	"WHERE user = :user";
-$results = getResults($database, $query, [':user'=>$_POST['user']]);
+$results = getResults($database, $query, $params);
 $allTimeStats = new elapsedTimeResult($results);
 
 echo"<ul>";

--- a/includes/recently_added.php
+++ b/includes/recently_added.php
@@ -5,7 +5,7 @@ require_once(dirname(__FILE__) . '/../config/config.php');
 require_once(dirname(__FILE__) . '/timeago.php');
 
 $width = filter_input(INPUT_GET, 'width', FILTER_VALIDATE_INT,
-	['options'=>['min_range'=>1]]);
+	array('options'=>array('min_range'=>1)));
 if (!isset($width) || $width === false) {
 	echo '<p>Width field is required.</p>';
 	$error_msg = 'PlexWatchWeb :: POST parameter "width" not found or invalid.';

--- a/info.php
+++ b/info.php
@@ -10,7 +10,7 @@ if (file_exists($guisettingsFile)) {
 
 $database = dbconnect();
 $itemId = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT,
-	['options'=>['min_range'=>1]]);
+	array('options'=>array('min_range'=>1)));
 if (!isset($itemId) || $itemId === false) {
 	echo "<p>ID field is required.</p>";
 	$error_msg = 'PlexWatchWeb :: POST parameter "id" not found or invalid.';
@@ -88,7 +88,7 @@ function printMetadata($xml) {
 
 function metaDataData($xml) {
 	$imgBase = 'includes/img.php?img=';
-	$data = [];
+	$data = array();
 	if ($xml->Video['type'] == 'episode') {
 		$data = episodeMetaData($xml);
 	} else if ($xml->Directory['type'] == 'show') {
@@ -116,7 +116,7 @@ function metaDataData($xml) {
 }
 
 function episodeMetaData($xml) {
-	$data = [];
+	$data = array();
 	$data['type'] = 'episode';
 	$data['xmlArt'] = $xml->Video['art'];
 	if ($xml->Video['parentThumb']) {
@@ -137,7 +137,7 @@ function episodeMetaData($xml) {
 }
 
 function showMetaData($xml) {
-	$data = [];
+	$data = array();
 	$data['type'] = 'show';
 	$data['xmlArt'] = $xml->Directory['art'];
 	$data['xmlThumb'] = $xml->Directory['thumb'];
@@ -150,7 +150,7 @@ function showMetaData($xml) {
 }
 
 function seasonMetaData($xml) {
-	$data = [];
+	$data = array();
 	$data['type'] = 'season';
 	$parentInfoPath = '/library/metadata/' . $xml->Directory['parentRatingKey'];
 	$parentXml = simplexml_load_string(getPMSData($parentInfoPath));
@@ -175,7 +175,7 @@ function seasonMetaData($xml) {
 }
 
 function movieMetaData($xml) {
-	$data = [];
+	$data = array();
 	$data['type'] = 'movie';
 	$data['xmlArt'] = $xml->Video['art'];
 	$data['xmlThumb'] = $xml->Video['thumb'];

--- a/settings.php
+++ b/settings.php
@@ -450,12 +450,25 @@ function printPHPSupport() {
 	echo '<li>';
 		$phpVersion = phpversion();
 		if (!empty($phpVersion)) {
+			// Minimum required: 5.3.3
+			if (defined('PHP_MAJOR_VERSION') && // >= 5.2.7
+				((PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION == 3 && PHP_RELEASE_VERSION >= 3) ||
+				(PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION > 3) ||
+				(PHP_MAJOR_VERSION > 5))) {
 				echo '<i class="icon icon-ok"></i> ';
 				echo 'PHP Version: <strong>';
 					echo '<span class="label label-success">';
 						echo 'v' . $phpVersion;
 					echo '</span>';
 				echo '</strong>';
+			} else {
+				echo '<i class="icon icon-warning-sign"></i> ';
+				echo 'PHP Version: <strong>';
+					echo '<span class="label label-important">';
+						echo 'v' . $phpVersion . ' (Min: 5.3.3)';
+					echo '</span>';
+				echo '</strong>';
+			}
 		} else {
 			echo '<i class="icon icon-warning-sign"></i> ';
 			echo 'PHP Version: <strong>';

--- a/stats.php
+++ b/stats.php
@@ -57,7 +57,7 @@ if (file_exists($guisettingsFile)) {
 				</div>
 			</div>
 		</div>
-		
+
 		<div class="container-fluid">
 			<div class="row-fluid">
 				<div class="span12">
@@ -127,9 +127,9 @@ $query = "SELECT " .
 	"GROUP BY strftime('%Y-%m-%d %H', datetime(time, 'unixepoch', 'localtime')) " .
 	"ORDER BY date ASC;";
 $hourlyPlays = getResults($database, $query);
-$hourlyPlayData = [];
+$hourlyPlayData = array();
 while ($row = $hourlyPlays->fetch(PDO::FETCH_ASSOC)) {
-	$hourlyPlayData[] = ["x"=>$row['date'], "y"=>(int) $row['count']];
+	$hourlyPlayData[] = array('x'=>$row['date'], 'y'=>(int) $row['count']);
 }
 
 $query = "SELECT " .
@@ -140,9 +140,9 @@ $query = "SELECT " .
 	"ORDER BY count(*) desc " .
 	"LIMIT 25;";
 $maxhourlyPlays = getResults($database, $query);
-$maxhourlyPlayData = [];
+$maxhourlyPlayData = array();
 while ($row = $maxhourlyPlays->fetch(PDO::FETCH_ASSOC)) {
-	$maxhourlyPlayData[] = ["x"=>$row['date'], "y"=>(int) $row['count']];
+	$maxhourlyPlayData[] = array('x'=>$row['date'], 'y'=>(int) $row['count']);
 }
 
 $query = "SELECT " .
@@ -153,9 +153,9 @@ $query = "SELECT " .
 	"ORDER BY time DESC " .
 	"LIMIT 30;";
 $dailyPlays = getResults($database, $query);
-$dailyPlayData = [];
+$dailyPlayData = array();
 while ($row = $dailyPlays->fetch(PDO::FETCH_ASSOC)) {
-	$dailyPlayData[] = ["x"=>$row['date'], "y"=>(int) $row['count']];
+	$dailyPlayData[] = array('x'=>$row['date'], 'y'=>(int) $row['count']);
 }
 
 $query = "SELECT " .
@@ -168,9 +168,9 @@ $query = "SELECT " .
 	"ORDER BY date DESC " .
 	"LIMIT 13;";
 $monthlyPlays = getResults($database, $query);
-$monthlyPlayData = [];
+$monthlyPlayData = array();
 while ($row = $monthlyPlays->fetch(PDO::FETCH_ASSOC)) {
-	$monthlyPlayData[] = ["x"=>$row['date'], "y"=>(int) $row['count']];
+	$monthlyPlayData[] = array('x'=>$row['date'], 'y'=>(int) $row['count']);
 }
 ?>
 		<!-- javascript

--- a/user.php
+++ b/user.php
@@ -90,7 +90,8 @@ if (file_exists($guisettingsFile)) {
 			"WHERE user = :user " .
 			"ORDER BY time DESC " .
 			"LIMIT 1;";
-		$userInfo = getResults($database, $query, [':user'=>$user]);
+		$params = array(':user'=>$user);
+		$userInfo = getResults($database, $query, $params);
 		?>
 		<div class="container-fluid">
 			<div class="row-fluid">
@@ -283,7 +284,7 @@ if (file_exists($guisettingsFile)) {
 						data: { user: '<?php echo $user; ?>' },
 						success: function(data) {
 							$("#user-recently-watched").html(data);
-							setCache('<?php echo $user;?>' + '-user-recently-watched-cache', data);
+							setCache('<?php echo $user; ?>' + '-user-recently-watched-cache', data);
 						}
 					});
 				}
@@ -409,7 +410,7 @@ if (file_exists($guisettingsFile)) {
 		<?php
 		$plexWatchDbTable = dbTable('user');
 
-		$db_array=array(
+		$db_array = array(
 			/* Use | as delimiter. Spell out columns names no SELECT * Table */
 			"sql"=>"SELECT id|time|user|platform|ip_address|title|time|" .
 				"paused_counter|stopped|xml|round((julianday(datetime(stopped," .
@@ -422,7 +423,7 @@ if (file_exists($guisettingsFile)) {
 		);
 
 		$javascript = ServerDataPDO::build_jquery_datatable($db_array,
-			'user_history_datatable','datafactory/get-info-modal.php');
+			'user_history_datatable', 'datafactory/get-info-modal.php');
 		echo $javascript;
 		?>
 		<script>


### PR DESCRIPTION
Update the code to be compatible with 5.3.3 and above.
Detailed per file compatibility:
charts.php: 5.0.0
history.php: 4.0.0
index.php: 4.0.0
info.php: 5.0.0
serverdatapdo.php: 5.2.0
settings.php: 5.3.3
stats.php: 5.2.0
user.php: 5.3.3
users.php: 5.1.0

includes/
configclass.php: 5.0.0
current_activity.php: 4.0.0
current_activity_header.php: 5.0.0
functions.php: 4.0.7
img.php: 5.0.0
myplex.php: 5.0.0
process_settings.php: 4.0.1
recently_added.php: 5.1.0
timeago.php: 4.0.0

datafactory/
get-info-modal.php: 5.1.0
get-library-stats.php: 5.1.0
get-user-ip-stats.php: 5.3.3
get-user-platform-stats.php: 5.1.0
get-user-recently-watched.php: 5.1.0
get-user-time-stats.php: 5.1.0

(This is a resubmit of the changes from https://github.com/ecleese/plexWatchWeb/pull/117 that got overwritten.)