### PR TITLE
Escape everything when encoding JS JSON

### DIFF
--- a/serverdatapdo.php
+++ b/serverdatapdo.php
@@ -170,7 +170,8 @@ class ServerDataPDO
         } else {
           $friendlyName = array();
         }
-        $friendlyName_json = json_encode($friendlyName);
+        $json_opts = JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_TAG;
+        $friendlyName_json = json_encode($friendlyName, $json_opts);
         /* Edit Jqeury Here */
         $js=  <<<EOT
 <!-- Start generated Jquery from $ajax_source_url  -->


### PR DESCRIPTION
Encode everything that the PHP json_encode() can when sending it to the client side JavaScript to prevent user input from breaking this.

Fixes https://github.com/ecleese/plexWatchWeb/issues/135.