### PR TITLE
Remove SOH character

### DIFF
--- a/user.php
+++ b/user.php
@@ -64,7 +64,7 @@ require_once(dirname(__FILE__) . '/includes/functions.php');
 						<li><a href="charts.php"><i class="fa fa-bar-chart fa-2x" data-toggle="tooltip" data-placement="bottom" title="Charts" id="charts"></i></a></li>
 						<li><a href="settings.php"><i class="fa fa-cogs fa-2x" data-toggle="tooltip" data-placement="bottom" title="Settings" id="settings"></i></a></li>
 					</ul>
-				</div>
+				</div>
 			</div>
 		</div>
 		<?php


### PR DESCRIPTION
Removes the SOH character added in https://github.com/ecleese/plexWatchWeb/commit/78e10f1c94460cca979118f2568aa22418f8ca15.
Also removes the extraneous new line at the end.