### PR TITLE
Send the token as a header

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -180,24 +180,13 @@ function getResults($database, $query, $params = NULL) {
 
 function getPMSData($path) {
 	global $settings;
-	if (strpos($path, '?')) {
-		$tokenPrefix = '&';
-	} else {
-		$tokenPrefix = '?';
-	}
-	if (strlen($settings->getPlexAuthToken()) > 0) {
-		$myPlexAuthToken = $tokenPrefix .
-			'X-Plex-Token=' . $settings->getPlexAuthToken();
-	} else {
-		$myPlexAuthToken = '';
-	}
-	$pmsUrl = $settings->getPmsUrl();
-// error_log('PMS URL: ' . $pmsUrl);
-	$url = $pmsUrl . $path . $myPlexAuthToken;
+	$url = $settings->getPmsUrl() . $path;
 	$curlHandle = curl_init($url);
 	curl_setopt($curlHandle, CURLOPT_RETURNTRANSFER, true);
 	curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, false);
 	curl_setopt($curlHandle, CURLOPT_SSL_VERIFYHOST, false);
+	curl_setopt($curlHandle, CURLOPT_HTTPHEADER,
+		array('X-Plex-Token: ' . $settings->getPlexAuthToken()));
 	$data = curl_exec($curlHandle);
 	if ($data === false || curl_getinfo($curlHandle, CURLINFO_HTTP_CODE) >= 400) {
 		curl_close($curlHandle);

--- a/includes/img.php
+++ b/includes/img.php
@@ -13,16 +13,13 @@ $path = '/photo/:/transcode?url=http://127.0.0.1:' . $settings->getPmsPort() .
 /**********************
  * FIXME: This should use getPMSData(), but we need the content-type
  */
-if ($settings->getPlexAuthToken()) {
-	$myPlexAuthToken = '&X-Plex-Token=' . $settings->getPlexAuthToken();
-} else {
-	$myPlexAuthToken = '';
-}
-$url = $settings->getPmsUrl() . $path . $myPlexAuthToken;
+$url = $settings->getPmsUrl() . $path;
 $curlHandle = curl_init($url);
 curl_setopt($curlHandle, CURLOPT_RETURNTRANSFER, true);
 curl_setopt($curlHandle, CURLOPT_SSL_VERIFYPEER, false);
 curl_setopt($curlHandle, CURLOPT_SSL_VERIFYHOST, false);
+curl_setopt($curlHandle, CURLOPT_HTTPHEADER,
+	array('X-Plex-Token: ' . $settings->getPlexAuthToken()));
 $img = curl_exec($curlHandle);
 if ($img === false || curl_getinfo($curlHandle, CURLINFO_HTTP_CODE) >= 400) {
 	curl_close($curlHandle);


### PR DESCRIPTION
Send the X-Plex-Token as a header instead of embedding into the URL. The potential downside of this is that it will make debugging when the token isn't being set slightly more difficult. This makes things slightly more secure, and the code simpler since nothing needs to be modified whether there is a token or not :wink:.